### PR TITLE
Init service discovery keys through cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ bundle exec shatter new <AppName>
 For now, app name should be in provided in UpperCamelCase.
 
 
-Open the console with `bin/console` and run:
+Init zookeeper with the required keys needed
 ```ruby
-ZK.new (Shatter::Config.zookeeper_host)
-zk.create("/shater_service_instances")
-zk.create("/shatter::response_data_locations")
-zk.close
+bundle exec shatter init_service_discovery
 ```
-Start the services with
+
+
+Finally, you start shatter by running both the web server and service applications.
 
 ```bash
 bin/service

--- a/exe/shatter
+++ b/exe/shatter
@@ -5,6 +5,7 @@ require "shatter"
 require "thor"
 require "erb"
 require "fileutils"
+require 'zk'
 $stdout.sync = true
 
 def safe_makedir(path)
@@ -14,10 +15,17 @@ end
 class ShatterCLI < Thor
   desc "init_service_discovery", "Sets up required keys for service discovery to work properly"
 
+  desc "init_service_discovery", "creates necessary keys in zookeeper"
   def init_service_discovery
+    Shatter.load_environment
     zk = ZK.new(Shatter::Config.zookeeper_host)
-    zk.create("/shater_service_instances")
-    zk.create("/shatter::response_data_locations")
+    [ 
+      Shatter::Util.instances_key,
+      Shatter::Util.zookeeper_response_key_root,
+    ].each do |key|
+      next if zk.exists?(key)
+      zk.create(key)
+    end
     zk.close
   end
 

--- a/lib/shatter.rb
+++ b/lib/shatter.rb
@@ -5,6 +5,18 @@ require_relative "./shatter/config"
 module Shatter
   class Error < StandardError; end
 
+  def self.root
+    current = Dir.pwd
+    root_dir = nil
+
+    while current.size >= 1 && root_dir.nil?
+      root_dir = current if Dir.children(current).include?("Gemfile")
+      current = File.expand_path("..", current) if root_dir.nil?
+      Dir.new(current)
+    end
+    root_dir
+  end
+
   def self.logger
     Util::Logger.instance
   end
@@ -17,6 +29,10 @@ module Shatter
 
   def self.loader
     loader
+  end
+
+  def self.load_environment
+    require "#{Shatter.root}/config/environment"
   end
 
   def self.load

--- a/lib/shatter/service/discovery.rb
+++ b/lib/shatter/service/discovery.rb
@@ -11,17 +11,17 @@ module Shatter
 
         def deregister_service(service_url)
           zk = connection_pool.checkout
-          if zk.exists?("/shater_service_instances/#{service_url}")
-            zk.delete("/shater_service_instances/#{service_url}")
-          end
+          key = Shatter::Util.instances_key
+          zk.delete("#{key}/#{service_url}") if zk.exists?("#{key}/#{service_url}")
           connection_pool.checkin(zk)
         end
 
         def register_service(service_url)
           Shatter.logger.info "Registering #{service_url} to zookeeper"
           zk = connection_pool.checkout
-          unless zk.exists?("/shater_service_instances/#{service_url}")
-            created = zk.create("/shater_service_instances/#{service_url}")
+          key = Shatter::Util.instances_key
+          unless zk.exists?("#{key}/#{service_url}")
+            created = zk.create("#{key}/#{service_url}")
             Shatter.logger.info "Registered #{created}"
           end
           connection_pool.checkin(zk)
@@ -33,7 +33,7 @@ module Shatter
 
         def service_instance_urls
           zk = connection_pool.checkout
-          urls = zk.children("/shater_service_instances")
+          urls = zk.children(Shatter::Util.instances_key)
           connection_pool.checkin(zk)
           urls
         end

--- a/lib/shatter/util.rb
+++ b/lib/shatter/util.rb
@@ -12,10 +12,18 @@ module Shatter
       end
     end
 
+    def self.instances_key
+      "/shater_service_instances"
+    end
+
+    def self.zookeeper_response_key_root
+      "/shatter::response_data_locations"
+    end
+
     def self.zookeeper_response_key(uuid)
       raise "Cant produce key without uuid" if uuid.nil?
 
-      "/shatter::response_data_locations/#{uuid}"
+      "#{zookeeper_response_key_root}/#{uuid}"
     end
   end
 end


### PR DESCRIPTION
Can now call `bundle exec shatter init_service_discovery` to create the necessary keys in zookeeper for shatter to operate. 

other goodies:
* can now call `Shatter.root` to get the root path of the project